### PR TITLE
CSYN-4 - Handle whitespaces in .csync file paths

### DIFF
--- a/csync.sh
+++ b/csync.sh
@@ -24,7 +24,7 @@ do
   if [[ -z "$GROUP_FILTER" || ( -n "$GROUP_FILTER" && ( -z "$GROUP" || "$GROUP" == "$GROUP_FILTER" ) ) ]]
   then
     echo "$SYNC_MODE ... $FROM > $TO"
-    rsync --stats $DELETE_FLAG -azh -r $FROM/* $TO/
+    rsync --stats $DELETE_FLAG -azh -r "$FROM/" "$TO/"
   else
     echo "Skipping ... $FROM > $TO"
   fi


### PR DESCRIPTION
**Business requirement:** https://trello.com/c/g7S9ARog/8-csyn-4-handle-whitespaces-in-csync-file-paths

**Description:** Till now whitespaces in destination and/or source paths weren't escaped and caused syncing error. This PR makes sure that whitespaced paths are passed as a single parameter (not multiple separated by whitespace).